### PR TITLE
change(People): Allow where searches for People; remove Person struct

### DIFF
--- a/lib/pco_api/people/people.ex
+++ b/lib/pco_api/people/people.ex
@@ -5,19 +5,23 @@ defmodule PcoApi.People.People do
   @endpoint "https://api.planningcenteronline.com/people/v2/people/"
 
   def get do
-    get("") |> Enum.map(fn(%{"attributes" => attrs, "id" => id, "links" => links}) ->
-      %Person{attributes: attrs, id: id, links: links}
-    end)
+    get("", [])
   end
 
-  def get({:id, id}) do
-    %{"attributes" => attrs, "id" => id, "links" => links} = get(id)
-    %Person{attributes: attrs, id: id, links: links}
+  # params = {attr, value} ie {"first_name", "geoffrey"}
+  def get({:where, params}) do
+    params = params |> Enum.map(fn ({attr, value}) -> {"where[#{attr}]", value} end)
+    get("", params)
   end
 
-  def get(url) do
-    case get(url, [], [hackney: [basic_auth: {PcoApi.key, PcoApi.secret}]]) do
-      {:ok, %HTTPoison.Response{body: body, status_code: 200}} ->
+  def get({:id, id}, []) do
+    get(id)
+  end
+
+  def get(url, options) do
+    # options = Keyword.merge(options, [hackney: [basic_auth: {PcoApi.key, PcoApi.secret}]])
+    case get(url, [], params: options, hackney: [basic_auth: {PcoApi.key, PcoApi.secret}]) do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         body["data"]
       {:ok, %HTTPoison.Response{body: body}} ->
         %{"errors" => [%{"detail" => detail, "title" => title}]} = body

--- a/lib/pco_api/people/person.ex
+++ b/lib/pco_api/people/person.ex
@@ -1,4 +1,0 @@
-defmodule PcoApi.People.Person do
-  @derive [Poison.Encoder]
-  defstruct [:attributes, :id, :links]
-end


### PR DESCRIPTION
I changed my mind regarding the `Person` struct. After further consideration, I don't think the API is the right place to structure the results. Its purpose should strictly be to assist in getting the information from the server.

The consumer of the API should be able to determine the structure of the results.

Also, this PR allows you to search for particular things through the api:

``` elixir
PcoApi.People.People.get({:where, [{"first_name", "geoffrey"}, {"last_name", "lessel"}]})
```

I don't think I like that but I'm going to go ahead and commit this. Here's where I'd like to head:

``` elixir
alias PcoApi.People.People

People.search
|> People.where({"first_name", "geoffrey"})
|> People.where({"last_name", "lessel"})
|> People.get
```

...or something like that.
