### PR TITLE
feature(Query): Add a query module

### DIFF
--- a/lib/pco_api/people/people.ex
+++ b/lib/pco_api/people/people.ex
@@ -1,6 +1,5 @@
 defmodule PcoApi.People.People do
   use HTTPoison.Base
-  alias PcoApi.People.Person
 
   @endpoint "https://api.planningcenteronline.com/people/v2/people/"
 
@@ -8,9 +7,7 @@ defmodule PcoApi.People.People do
     get("", [])
   end
 
-  # params = {attr, value} ie {"first_name", "geoffrey"}
-  def get({:where, params}) do
-    params = params |> Enum.map(fn ({attr, value}) -> {"where[#{attr}]", value} end)
+  def get(params) when is_list(params) do
     get("", params)
   end
 
@@ -18,9 +15,8 @@ defmodule PcoApi.People.People do
     get(id)
   end
 
-  def get(url, options) do
-    # options = Keyword.merge(options, [hackney: [basic_auth: {PcoApi.key, PcoApi.secret}]])
-    case get(url, [], params: options, hackney: [basic_auth: {PcoApi.key, PcoApi.secret}]) do
+  def get(url, params) do
+    case get(url, [], params: params, hackney: [basic_auth: {PcoApi.key, PcoApi.secret}]) do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         body["data"]
       {:ok, %HTTPoison.Response{body: body}} ->

--- a/lib/pco_api/query/query.ex
+++ b/lib/pco_api/query/query.ex
@@ -1,0 +1,10 @@
+defmodule PcoApi.Query do
+  def where({_, _} = param), do: where([], param)
+  def where(params, {attr, value}) when is_list(params) do
+    add_param(params, {"where[#{attr}]", value})
+  end
+
+  defp add_param(params, param) do
+    [param | params]
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,8 @@
+%{"certifi": {:hex, :certifi, "0.4.0"},
+  "hackney": {:hex, :hackney, "1.6.0"},
+  "httpoison": {:hex, :httpoison, "0.8.3"},
+  "idna": {:hex, :idna, "1.2.0"},
+  "metrics": {:hex, :metrics, "1.0.1"},
+  "mimerl": {:hex, :mimerl, "1.0.2"},
+  "poison": {:hex, :poison, "2.1.0"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0"}}


### PR DESCRIPTION
This adds a reusable module that could potentially be used throughout the API in the different app modules (`People` being the only one right now). Usage:

``` elixir
alias PcoApi.People.People
import PcoApi.Query

where({"first_name", "jesse"})
|> where({"last_name", "anderson"})
|> People.get
```
