### PR TITLE
Add an Actions module that can be used in the various other modules

### DIFF
--- a/lib/pco_api/actions.ex
+++ b/lib/pco_api/actions.ex
@@ -1,0 +1,33 @@
+defmodule PcoApi.Actions do
+  defmacro __using__(_opts) do
+    quote do
+      import PcoApi.Actions
+      use HTTPoison.Base
+
+      def get, do: get("", [])
+      def get(url) when is_binary(url), do: get(url, [])
+      def get(params) when is_list(params), do: get("", params)
+      def get({:id, id}, []), do: get(id)
+      def get(url, params) do
+        case get(url, [], params: params, hackney: [basic_auth: {PcoApi.key, PcoApi.secret}]) do
+          {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+            body["data"]
+          {:ok, %HTTPoison.Response{body: body}} ->
+            %{"errors" => [%{"detail" => detail, "title" => title}]} = body
+            raise "Request returned non-200 response. Error: #{title}: #{detail}"
+          {:error, _} ->
+            raise "PcoApi.People error"
+        end
+      end
+
+      def process_url(url), do: api_endpoint <> url
+      def process_response_body(body), do: body |> Poison.decode!
+    end
+  end
+
+  defmacro endpoint(url) do
+    quote do
+      def unquote(:api_endpoint)(), do: unquote(url)
+    end
+  end
+end

--- a/lib/pco_api/people.ex
+++ b/lib/pco_api/people.ex
@@ -1,2 +1,9 @@
 defmodule PcoApi.People do
+  use PcoApi.Actions
+
+  endpoint "https://api.planningcenteronline.com/people/v2/"
+
+  def me do
+    get("me", [])
+  end
 end

--- a/lib/pco_api/people/people.ex
+++ b/lib/pco_api/people/people.ex
@@ -1,38 +1,5 @@
 defmodule PcoApi.People.People do
-  use HTTPoison.Base
+  use PcoApi.Actions
 
-  @endpoint "https://api.planningcenteronline.com/people/v2/people/"
-
-  def get do
-    get("", [])
-  end
-
-  def get(params) when is_list(params) do
-    get("", params)
-  end
-
-  def get({:id, id}, []) do
-    get(id)
-  end
-
-  def get(url, params) do
-    case get(url, [], params: params, hackney: [basic_auth: {PcoApi.key, PcoApi.secret}]) do
-      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        body["data"]
-      {:ok, %HTTPoison.Response{body: body}} ->
-        %{"errors" => [%{"detail" => detail, "title" => title}]} = body
-        raise "Request returned non-200 response. Error: #{title}: #{detail}"
-      {:error, _} ->
-        raise "PcoApi.People error"
-    end
-  end
-
-  def process_url(url) do
-    @endpoint <> url
-  end
-
-  def process_response_body(body) do
-    body
-    |> Poison.decode!
-  end
+  endpoint "https://api.planningcenteronline.com/people/v2/people/"
 end

--- a/lib/pco_api/query/query.ex
+++ b/lib/pco_api/query/query.ex
@@ -1,5 +1,5 @@
 defmodule PcoApi.Query do
-  def where({_, _} = param), do: where([], param)
+  def where(param) when is_tuple(param), do: where([], param)
   def where(params, {attr, value}) when is_list(params) do
     add_param(params, {"where[#{attr}]", value})
   end


### PR DESCRIPTION
Actions adds the various `get` functions that interacts with the actual API endpoints. It also defines a new macro that `use`ing modules needs to implement in order to tell Actions where to send the requests.

This allows other/new modules to use the RESTful actions that `Actions` defines. For example, I think with this we could define a `Household` module like this:

``` elixir
defmodule PcoApi.People.Household do
  use PcoApi.Actions
  endpoint "https://api.planningcenteronline.com/people/v2/households/"
end
```

and use it

``` elixir
import PcoApi.Query
alias PcoApi.People.Household

where({"member_count", "3"})
|> Household.get
```

I haven't tried that specific thing yet, but in this PR is a `me` implementation on `PcoApi.People` that is a similar idea.
