### PR TITLE
refactor(Workflow):  pass params through

### DIFF
--- a/lib/pco_api/actions.ex
+++ b/lib/pco_api/actions.ex
@@ -4,11 +4,13 @@ defmodule PcoApi.Actions do
       import PcoApi.Actions
       use HTTPoison.Base
 
-      def get, do: get("", [])
-      def get(url) when is_binary(url), do: get(url, [])
-      def get(params) when is_list(params), do: get("", params)
+      def get, do: do_get("", [])
+      def get(url) when is_binary(url), do: do_get(url, [])
+      def get(params) when is_list(params), do: do_get("", params)
       def get({:id, id}, []), do: get(id)
-      def get(url, params) do
+      def get(url, params) when is_map(params), do: do_get(url, Map.to_list(params))
+
+      def do_get(url, params) do
         case get(url, [], params: params, hackney: [basic_auth: {PcoApi.key, PcoApi.secret}]) do
           {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
             body["data"]

--- a/lib/pco_api/people/workflow.ex
+++ b/lib/pco_api/people/workflow.ex
@@ -2,63 +2,62 @@ defmodule PcoApi.People.Workflow do
   @moduledoc """
   Let's you access Workflows, WorkflowCards, WorkflowCardActivities, WorkflowCardNotes, WorkflowSteps, and WorkflowTasks
   """
-
-  # Activity
-  def get(id, [{:card_id, card_id}, {:activity_id, activity_id} | params]) do
-    id <> "/cards/" <> card_id <> "/activities/" <> activity_id
-    |> get(params)
-  end
-
-  # Note
-  def get(id, [{:card_id, card_id}, {:note_id, note_id} | params]) do
-    id <> "/cards/" <> card_id <> "/notes/" <> note_id
-    |> get(params)
-  end
-
-  # Task
-  def get(id, [{:card_id, card_id}, {:task_id, task_id} | params]) do
-    id <> "/cards/" <> card_id <> "/tasks/" <> task_id
-    |> get(params)
-  end
-
-  # Card
-  def get(id, [{:card_id, card_id} | params]) do
-    id <> "/cards/" <> card_id
-    |> get(params)
-  end
-
-  # Step
-  def get(id, [{:step_id, step_id} | params]) do
-    id <> "/steps/" <> step_id
-    |> get(params)
-  end
-
-  def cards(id, params \\ []) do
-    id <> "/cards"
-    |> get(params)
-  end
-
-  def activities(id, [{:card_id, card_id} | params]) do
-    id <> "/cards/" <> card_id <> "/activities"
-    |> get(params)
-  end
-
-  def notes(id, [{:card_id, card_id} | params]) do
-    id <> "/cards/" <> card_id <> "/notes"
-    |> get(params)
-  end
-
-  def steps(id, params \\ []) do
-    id <> "/steps"
-    |> get(params)
-  end
-
-  def tasks(id, [{:card_id, card_id} | params]) do
-    id <> "/cards/" <> card_id <> "/tasks"
-    |> get(params)
-  end
-
   use PcoApi.Actions
 
   endpoint "https://api.planningcenteronline.com/people/v2/workflows/"
+
+  def get(id, params) when is_list(params), do: get(id, Map.new(params))
+
+  def get(id, %{card_id: card_id, activity_id: activity_id} = params) do
+    url_str = id <> "/cards/" <> card_id <> "/activities/" <> activity_id
+    get(url_str, params)
+  end
+
+  def get(id, %{card_id: card_id, note_id: note_id} = params) do
+    url_str = id <> "/cards/" <> card_id <> "/notes/" <> note_id
+    get(url_str, params)
+  end
+
+  def get(id, %{card_id: card_id, task_id: task_id} = params) do
+    url_str = id <> "/cards/" <> card_id <> "/tasks/" <> task_id
+    get(url_str, params)
+  end
+
+  def get(id, %{card_id: card_id} = params) do
+    url_str = id <> "/cards/" <> card_id
+    get(url_str, params)
+  end
+
+  def get(id, %{step_id: step_id} = params) do
+    url_str = id <> "/steps/" <> step_id
+    get(url_str, params)
+  end
+
+  def cards(id, params \\ []) do
+    url_str = id <> "/cards"
+    get(url_str, params)
+  end
+
+  def steps(id, params \\ []) do
+    url_str = id <> "/steps"
+    get(url_str, params)
+  end
+
+  def activities(id, params) when is_list(params), do: activities(id, Map.new(params))
+  def activities(id, %{card_id: card_id} = params) do
+    url_str = id <> "/cards/" <> card_id <> "/activities"
+    get(url_str, params)
+  end
+
+  def notes(id, params) when is_list(params), do: notes(id, Map.new(params))
+  def notes(id, %{card_id: card_id} = params) do
+    url_str = id <> "/cards/" <> card_id <> "/notes"
+    get(url_str, params)
+  end
+
+  def tasks(id, params) when is_list(params), do: tasks(id, Map.new(params))
+  def tasks(id, %{card_id: card_id} = params) do
+    url_str = id <> "/cards/" <> card_id <> "/tasks"
+    get(url_str, params)
+  end
 end

--- a/lib/pco_api/people/workflow.ex
+++ b/lib/pco_api/people/workflow.ex
@@ -4,58 +4,58 @@ defmodule PcoApi.People.Workflow do
   """
 
   # Activity
-  def get(id, card_id: card_id, activity_id: activity_id) do
+  def get(id, [{:card_id, card_id}, {:activity_id, activity_id} | params]) do
     id <> "/cards/" <> card_id <> "/activities/" <> activity_id
-    |> get([])
+    |> get(params)
   end
 
   # Note
-  def get(id, card_id: card_id, note_id: note_id) do
+  def get(id, [{:card_id, card_id}, {:note_id, note_id} | params]) do
     id <> "/cards/" <> card_id <> "/notes/" <> note_id
-    |> get([])
+    |> get(params)
   end
 
   # Task
-  def get(id, card_id: card_id, task_id: task_id) do
+  def get(id, [{:card_id, card_id}, {:task_id, task_id} | params]) do
     id <> "/cards/" <> card_id <> "/tasks/" <> task_id
-    |> get([])
+    |> get(params)
   end
 
   # Card
-  def get(id, card_id: card_id) do
+  def get(id, [{:card_id, card_id} | params]) do
     id <> "/cards/" <> card_id
-    |> get([])
+    |> get(params)
   end
 
   # Step
-  def get(id, step_id: step_id) do
+  def get(id, [{:step_id, step_id} | params]) do
     id <> "/steps/" <> step_id
-    |> get([])
+    |> get(params)
   end
 
-  def cards(id) do
+  def cards(id, params \\ []) do
     id <> "/cards"
-    |> get([])
+    |> get(params)
   end
 
-  def activities(id, card_id: card_id) do
+  def activities(id, [{:card_id, card_id} | params]) do
     id <> "/cards/" <> card_id <> "/activities"
-    |> get([])
+    |> get(params)
   end
 
-  def notes(id, card_id: card_id) do
+  def notes(id, [{:card_id, card_id} | params]) do
     id <> "/cards/" <> card_id <> "/notes"
-    |> get([])
+    |> get(params)
   end
 
-  def steps(id) do
+  def steps(id, params \\ []) do
     id <> "/steps"
-    |> get([])
+    |> get(params)
   end
 
-  def tasks(id, card_id: card_id) do
+  def tasks(id, [{:card_id, card_id} | params]) do
     id <> "/cards/" <> card_id <> "/tasks"
-    |> get([])
+    |> get(params)
   end
 
   use PcoApi.Actions


### PR DESCRIPTION
There might be a better way, but in order to keep our setup and allow for params I had to drop the definition pattern matching out of the friendly syntax for keyword lists. This lets Workflow work the same as before but now strips the params used for `card_id`, etc and passes the leftover params to the actions.
