### PR TITLE
refactor(Workflow): add url builder functions

### DIFF
--- a/lib/pco_api/people/workflow.ex
+++ b/lib/pco_api/people/workflow.ex
@@ -1,62 +1,54 @@
 defmodule PcoApi.People.Workflow do
   @moduledoc """
-  Let's you access Workflows, WorkflowCards, WorkflowCardActivities, WorkflowCardNotes, WorkflowSteps, and WorkflowTasks
+  Access Workflows, WorkflowCards, WorkflowCardActivities, WorkflowCardNotes, WorkflowSteps, and WorkflowTasks
   """
 
-  # Activity
-  def get(id, [{:card_id, card_id}, {:activity_id, activity_id} | params]) do
-    id <> "/cards/" <> card_id <> "/activities/" <> activity_id
-    |> get(params)
+  def get(url_str, [{:card_id, card_id} | params]) do
+    url_str |> add_card_url(card_id) |> get(params)
   end
 
-  # Note
-  def get(id, [{:card_id, card_id}, {:note_id, note_id} | params]) do
-    id <> "/cards/" <> card_id <> "/notes/" <> note_id
-    |> get(params)
+  def get(url_str, [{:step_id, step_id} | params]) do
+    url_str |> add_step_url(card_id) |> get(params)
   end
 
-  # Task
-  def get(id, [{:card_id, card_id}, {:task_id, task_id} | params]) do
-    id <> "/cards/" <> card_id <> "/tasks/" <> task_id
-    |> get(params)
+  def get(url_str, [{:note_id, note_id} | params]) do
+    url_str |> add_note_url(note_id) |> get(params)
   end
 
-  # Card
-  def get(id, [{:card_id, card_id} | params]) do
-    id <> "/cards/" <> card_id
-    |> get(params)
+  def get(url_str, [{:activity_id, activity_id} | params]) do
+    url_str |> add_activity_url(activity_id) |> get(params)
   end
 
-  # Step
-  def get(id, [{:step_id, step_id} | params]) do
-    id <> "/steps/" <> step_id
-    |> get(params)
+  def get(url_str, [{:task_id, task_id} | params]) do
+    url_str |> add_task_url(task_id) |> get(params)
   end
 
-  def cards(id, params \\ []) do
-    id <> "/cards"
-    |> get(params)
+  def activities(url_str, [{:card_id, card_id} | params]) do
+    url_str |> add_card_url(card_id) |> add_activity_url("") |> get(params)
   end
 
-  def activities(id, [{:card_id, card_id} | params]) do
-    id <> "/cards/" <> card_id <> "/activities"
-    |> get(params)
+  def notes(url_str, [{:card_id, card_id} | params]) do
+    url_str |> add_card_url(card_id) |> add_note_url("") |> get(params)
   end
 
-  def notes(id, [{:card_id, card_id} | params]) do
-    id <> "/cards/" <> card_id <> "/notes"
-    |> get(params)
+  def steps(url_str, params \\ []) do
+    url_str |> add_step_url("") |> get(params)
   end
 
-  def steps(id, params \\ []) do
-    id <> "/steps"
-    |> get(params)
+  def tasks(url_str, [{:card_id, card_id} | params]) do
+    url_str |> add_card_url(card_id) |> add_task_url |> get(params)
   end
 
-  def tasks(id, [{:card_id, card_id} | params]) do
-    id <> "/cards/" <> card_id <> "/tasks"
-    |> get(params)
-  end
+  defp add_card_url(url_str, card_id \\ ""),
+    do: url_str <> "/cards/" <> card_id
+  defp add_step_url(url_str, step_id \\ ""),
+    do: url_str <> "/steps/" <> step_id
+  defp add_note_url(url_str, note_id \\ ""),
+    do: url_str <> "/notes/" <> note_id
+  defp add_activity_url(url_str, activity_id \\ ""),
+    do: url_str <> "/activities/" <> activity_id
+  defp add_task_url(url_str, task_id \\ ""),
+    do: url_str <> "/tasks/" <> task_id
 
   use PcoApi.Actions
 

--- a/lib/pco_api/people/workflow.ex
+++ b/lib/pco_api/people/workflow.ex
@@ -4,58 +4,58 @@ defmodule PcoApi.People.Workflow do
   """
 
   # Activity
-  def get(id, card_id: card_id, activity_id: activity_id) do
+  def get(id, [{:card_id, card_id}, {:activity_id, activity_id} | params]) do
     id <> "/cards/" <> card_id <> "/activities/" <> activity_id
-    |> get([])
+    |> get(params)
   end
 
   # Note
-  def get(id, card_id: card_id, note_id: note_id) do
+  def get(id, [{:card_id, card_id}, {:note_id, note_id} | params]) do
     id <> "/cards/" <> card_id <> "/notes/" <> note_id
-    |> get([])
+    |> get(params)
   end
 
   # Task
-  def get(id, card_id: card_id, task_id: task_id) do
+  def get(id, [{:card_id, card_id}, {:task_id, task_id} | params]) do
     id <> "/cards/" <> card_id <> "/tasks/" <> task_id
-    |> get([])
+    |> get(params)
   end
 
   # Card
-  def get(id, card_id: card_id) do
+  def get(id, [{:card_id, card_id} | params]) do
     id <> "/cards/" <> card_id
-    |> get([])
+    |> get(params)
   end
 
   # Step
-  def get(id, step_id: step_id) do
+  def get(id, [{:step_id, step_id} | params]) do
     id <> "/steps/" <> step_id
-    |> get([])
+    |> get(params)
   end
 
-  def cards(id) do
+  def cards(id, params \\ []) do
     id <> "/cards"
-    |> get([])
+    |> get(params)
   end
 
-  def activities(id, card_id: card_id) do
+  def activities(id, [{:card_id, card_id} | params]) do
     id <> "/cards/" <> card_id <> "/activities"
-    |> get([])
+    |> get(params)
   end
 
-  def notes(id, card_id: card_id) do
+  def notes(id, [{:card_id, card_id} | params]) do
     id <> "/cards/" <> card_id <> "/notes"
-    |> get([])
+    |> get(params)
   end
 
-  def steps(id) do
+  def steps(id, params \\ []) do
     id <> "/steps"
-    |> get([])
+    |> get(params)
   end
 
-  def tasks(id, card_id: card_id) do
+  def tasks(id, [{:card_id, card_id} | params]) do
     id <> "/cards/" <> card_id <> "/tasks"
-    |> get([])
+    |> get(params)
   end
 
   use PcoApi.Actions

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,8 @@ defmodule PcoApi.Mixfile do
       {:httpoison, "~> 0.8"},
       {:poison, "~> 2.0"},
       {:ex_doc, "~> 0.11", only: :dev},
-      {:earmark, "~> 0.1", only: :dev}
+      {:earmark, "~> 0.1", only: :dev},
+      {:credo, "~> 0.3", only: [:dev, :test]}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
-%{"certifi": {:hex, :certifi, "0.4.0"},
+%{"bunt": {:hex, :bunt, "0.1.5"},
+  "certifi": {:hex, :certifi, "0.4.0"},
+  "credo": {:hex, :credo, "0.3.13"},
   "earmark": {:hex, :earmark, "0.2.1"},
   "ex_doc": {:hex, :ex_doc, "0.11.5"},
   "hackney": {:hex, :hackney, "1.6.0"},


### PR DESCRIPTION
Credo (Elixir code analysis tool) gave me a warning that my pipeline functions are "supposed" to start with a value, rather than the string concatenation I was doing before.

This gave me the idea to create mini functions to build the different parts of the URL and just pipe into those with the `workflow_id` as the initial `url_str` that I would build off of.
