### PR TITLE
change(Actions): Remove .get_list function; replace with extra .gets

### DIFF
--- a/lib/pco_api/actions.ex
+++ b/lib/pco_api/actions.ex
@@ -20,12 +20,9 @@ defmodule PcoApi.Actions do
       def get(id) when is_integer(id), do: get(Integer.to_string(id))
       def get(url) when is_binary(url), do: request(:get, url, []) |> new
       def get(params) when is_list(params), do: get(params, "")
+      def get(%PcoApi.Record{links: %{"self" => self}}), do: get self
+      def get(%PcoApi.Record{id: id}), do: get String.to_integer(id)
       def get(params, url) when is_list(params), do: request(:get, url, params) |> new
-
-      def get_list([%PcoApi.Record{} | rest] = records), do: do_get_list(records)
-      defp do_get_list([]), do: []
-      defp do_get_list(%PcoApi.Record{} = record), do: get record.links["self"]
-      defp do_get_list([%PcoApi.Record{} = first | rest]), do: [do_get_list(first) | do_get_list(rest)]
 
       def new(results) when is_list(results), do: results |> Enum.map(&(&1 |> new))
       def new(%{"id" => id, "links" => links, "attributes" => attrs, "type" => type}) do

--- a/test/pco_api/people/person_test.exs
+++ b/test/pco_api/people/person_test.exs
@@ -24,7 +24,7 @@ defmodule PcoApi.People.PersonTest do
     Bypass.expect bypass, fn conn ->
       Plug.Conn.resp(conn, 200, Fixture.read("people_list.json"))
     end
-    assert [%PcoApi.Record{} | rest] = Person.get
+    assert [%PcoApi.Record{} | _rest] = Person.get
   end
 
   test ".get(id) returns a single record", %{bypass: bypass} do
@@ -57,14 +57,20 @@ defmodule PcoApi.People.PersonTest do
     |> Person.get("foo")
   end
 
-  #.get_list
-  test ".get_list takes a list of Records and queries the details of each", %{bypass: bypass} do
+  test ".get retrieves the details of a Person when passed a single record", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
-      assert conn.request_path |> String.match?(~r{/people/v2/people/[12]})
+      assert "/people/v2/people/1" == conn.request_path
       Plug.Conn.resp(conn, 200, Fixture.read("me.json"))
     end
     me = %PcoApi.Record{links: %{"self" => "https://api.planningcenteronline.com/people/v2/people/1"}}
-    em = %PcoApi.Record{links: %{"self" => "https://api.planningcenteronline.com/people/v2/people/2"}}
-    [me, em] |> Person.get_list
+    me |> Person.get
+  end
+
+  test ".get gets Person details even if no self link", %{bypass: bypass} do
+    Bypass.expect bypass, fn conn ->
+      assert "/people/v2/people/1000" == conn.request_path
+      Plug.Conn.resp(conn, 200, Fixture.read("me.json"))
+    end
+    %PcoApi.Record{id: "1000", links: %{}} |> Person.get
   end
 end


### PR DESCRIPTION
Instead of providing a function to get a list of records, let's let the user do that. Along those lines, create a way to get the details of a Record through get, whether through `links["self"]` or, as a fallback, constructing from the id.

``` elixir
list_of_lessels = PcoApi.Query.where(last_name: "Lessel") |> PcoApi.People.Person.get
lessel_deets = list_of_lessels
               |> Enum.map(fn(a_lessel) -> a_lessel |> PcoApi.People.Person.get)
```
