### PR TITLE
change(Actions): Major breaking rewrite of Actions

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -31,4 +31,3 @@ import_config "#{Mix.env}.exs"
 
 config :pco_api, :api_key, System.get_env("PCO_API_KEY")
 config :pco_api, :api_secret, System.get_env("PCO_API_SECRET")
-config :bypass, enable_debug_log: false

--- a/lib/pco_api/actions.ex
+++ b/lib/pco_api/actions.ex
@@ -3,76 +3,11 @@ defmodule PcoApi.Actions do
     quote do
       import PcoApi.Actions
       use PcoApi.Client
-      # use HTTPoison.Base
 
       use PcoApi.Actions.Get
       use PcoApi.Actions.Create
-
-      # def request(:get, url, params) do
-      #   case get(url, [], params: params, hackney: [basic_auth: {PcoApi.key, PcoApi.secret}]) do
-      #     {:ok, %HTTPoison.Response{status_code: code, body: body}} when (code in 200..299) ->
-      #       cond do
-      #         %{"data" => data} = body -> data
-      #         true -> body
-      #       end
-      #     {:ok, %HTTPoison.Response{body: body}} ->
-      #       %{"errors" => [%{"detail" => detail, "title" => title}]} = body
-      #       raise "Request returned non-200 response. Error: #{title}: #{detail}"
-      #     {:error, _} ->
-      #       raise "PcoApi.People error"
-      #   end
-      # end
-
-      # if Keyword.get(unquote(opts), :only, []) |> Enum.member?(:get) do
-      #   import PcoApi.Actions.Get
-      #   # def get, do: get("")
-      #   # def get(id) when is_integer(id), do: get(Integer.to_string(id))
-      #   # def get(url) when is_binary(url), do: request(:get, url, []) |> to_record
-      #   # def get(params) when is_list(params), do: get(params, "")
-      #   # def get(params, url) when is_list(params), do: request(:get, url, params) |> to_record
-      # end
-      # use PcoApi.Actions.Create
-
-      # def create(%PcoApi.Record{attributes: _, type: _} = record), do: create(record, "")
-      # def create(%PcoApi.Record{attributes: _, type: _} = record, url) when is_binary(url) do
-      #   # TODO: Error handling for when the record isn't created
-      #   record |> PcoApi.Record.to_json |> create(url)
-      # end
-      # def create(json, url) when is_binary(json) do
-      #   url
-      #   |> post(json, [], hackney: [basic_auth: {PcoApi.key, PcoApi.secret}])
-      #   |> do_create
-      # end
-
-      # defp do_create({:ok, %HTTPoison.Response{status_code: code, body: %{"data" => data}}}) when (code in 200..299) do
-      #   data |> to_record
-      # end
-      # defp do_create({:ok, %HTTPoison.Response{status_code: code, body: body}}) when (code in 200..299), do: body
-      # defp do_create({:ok, %HTTPoison.Response{body: body}}), do: raise "PcoApi ok, but not ok: #{IO.inspect body}"
-      # defp do_create({:error, err}), do: raise "PcoApi error: #{IO.inspect err}"
-
-      # def self(%PcoApi.Record{links: %{"self" => self}}), do: get self
-      # def self(%PcoApi.Record{id: id}), do: get String.to_integer(id)
-
-      # def new(attrs) when is_list(attrs) do
-      #   attrs_map = Enum.into(attrs, %{}, fn({k,v}) -> {Atom.to_string(k), v} end)
-      #   %PcoApi.Record{attributes: attrs_map, type: __MODULE__.type}
-      # end
-
-      # HTTPoison.Base API
-
-      # if this is a full URL, don't add the endpoint. This allows using direct links.
-      # def process_url(url) do
-      #   configured_endpoint = __MODULE__.api_endpoint
-      #   endpoint_base = Application.get_env(:pco_api, :endpoint_base)
-      #   case url |> String.starts_with?(endpoint_base) do
-      #     true  -> url
-      #     false ->
-      #       url = endpoint_base <> configured_endpoint <> String.replace(url, ~r|^https?://[0-9a-zA-Z:.]+/#{configured_endpoint}|U, "") # enforce the endpoint
-      #       url
-      #   end
-      # end
-      # def process_response_body(body), do: body |> Poison.decode!
+      use PcoApi.Actions.Self
+      use PcoApi.Actions.New
     end
   end
 
@@ -83,10 +18,4 @@ defmodule PcoApi.Actions do
       end
     end
   end
-
-  # defmacro record_type(type) do
-  #   quote do
-  #     def unquote(:type)(), do: unquote(type)
-  #   end
-  # end
 end

--- a/lib/pco_api/actions.ex
+++ b/lib/pco_api/actions.ex
@@ -4,17 +4,23 @@ defmodule PcoApi.Actions do
       import PcoApi.Actions
       use PcoApi.Client
 
-      use PcoApi.Actions.Get
-      use PcoApi.Actions.Create
-      use PcoApi.Actions.Self
-      use PcoApi.Actions.New
-    end
-  end
-
-  defmacro endpoint(url) do
-    quote do
-      def unquote(:api_endpoint)() do
-        unquote(url)
+      case unquote(opts) |> Keyword.has_key?(:only) do
+        true ->
+          unquote(opts) |> Keyword.fetch!(:only) |> Enum.each(fn(option) ->
+            case option do
+              :list -> use PcoApi.Actions.List
+              :get  -> use PcoApi.Actions.Get
+              :create -> use PcoApi.Actions.Create
+              :self -> use PcoApi.Actions.Self
+              :new -> use PcoApi.Actions.New
+            end
+          end)
+        _ ->
+          use PcoApi.Actions.List
+          use PcoApi.Actions.Get
+          use PcoApi.Actions.Create
+          use PcoApi.Actions.Self
+          use PcoApi.Actions.New
       end
     end
   end

--- a/lib/pco_api/actions.ex
+++ b/lib/pco_api/actions.ex
@@ -1,73 +1,78 @@
 defmodule PcoApi.Actions do
-  defmacro __using__(_opts) do
+  defmacro __using__(opts) do
     quote do
       import PcoApi.Actions
-      use HTTPoison.Base
+      use PcoApi.Client
+      # use HTTPoison.Base
 
-      def request(:get, url, params) do
-        case get(url, [], params: params, hackney: [basic_auth: {PcoApi.key, PcoApi.secret}]) do
-          {:ok, %HTTPoison.Response{status_code: code, body: body}} when (code in 200..299) ->
-            cond do
-              %{"data" => data} = body -> data
-              true -> body
-            end
-          {:ok, %HTTPoison.Response{body: body}} ->
-            %{"errors" => [%{"detail" => detail, "title" => title}]} = body
-            raise "Request returned non-200 response. Error: #{title}: #{detail}"
-          {:error, _} ->
-            raise "PcoApi.People error"
-        end
-      end
+      use PcoApi.Actions.Get
+      use PcoApi.Actions.Create
 
-      def get, do: get("")
-      def get(id) when is_integer(id), do: get(Integer.to_string(id))
-      def get(url) when is_binary(url), do: request(:get, url, []) |> to_record
-      def get(params) when is_list(params), do: get(params, "")
-      def get(params, url) when is_list(params), do: request(:get, url, params) |> to_record
+      # def request(:get, url, params) do
+      #   case get(url, [], params: params, hackney: [basic_auth: {PcoApi.key, PcoApi.secret}]) do
+      #     {:ok, %HTTPoison.Response{status_code: code, body: body}} when (code in 200..299) ->
+      #       cond do
+      #         %{"data" => data} = body -> data
+      #         true -> body
+      #       end
+      #     {:ok, %HTTPoison.Response{body: body}} ->
+      #       %{"errors" => [%{"detail" => detail, "title" => title}]} = body
+      #       raise "Request returned non-200 response. Error: #{title}: #{detail}"
+      #     {:error, _} ->
+      #       raise "PcoApi.People error"
+      #   end
+      # end
 
-      def create(%PcoApi.Record{attributes: _, type: _} = record), do: create(record, "")
-      def create(%PcoApi.Record{attributes: _, type: _} = record, url) when is_binary(url) do
-        # TODO: Error handling for when the record isn't created
-        record |> PcoApi.Record.to_json |> create(url)
-      end
-      def create(json, url) when is_binary(json) do
-        url
-        |> post(json, [], hackney: [basic_auth: {PcoApi.key, PcoApi.secret}])
-        |> do_create
-      end
+      # if Keyword.get(unquote(opts), :only, []) |> Enum.member?(:get) do
+      #   import PcoApi.Actions.Get
+      #   # def get, do: get("")
+      #   # def get(id) when is_integer(id), do: get(Integer.to_string(id))
+      #   # def get(url) when is_binary(url), do: request(:get, url, []) |> to_record
+      #   # def get(params) when is_list(params), do: get(params, "")
+      #   # def get(params, url) when is_list(params), do: request(:get, url, params) |> to_record
+      # end
+      # use PcoApi.Actions.Create
 
-      defp do_create({:ok, %HTTPoison.Response{status_code: code, body: %{"data" => data}}}) when (code in 200..299) do
-        data |> to_record
-      end
-      defp do_create({:ok, %HTTPoison.Response{status_code: code, body: body}}) when (code in 200..299), do: body
-      defp do_create({:ok, %HTTPoison.Response{body: body}}), do: raise "PcoApi ok, but not ok: #{IO.inspect body}"
-      defp do_create({:error, err}), do: raise "PcoApi error: #{IO.inspect err}"
+      # def create(%PcoApi.Record{attributes: _, type: _} = record), do: create(record, "")
+      # def create(%PcoApi.Record{attributes: _, type: _} = record, url) when is_binary(url) do
+      #   # TODO: Error handling for when the record isn't created
+      #   record |> PcoApi.Record.to_json |> create(url)
+      # end
+      # def create(json, url) when is_binary(json) do
+      #   url
+      #   |> post(json, [], hackney: [basic_auth: {PcoApi.key, PcoApi.secret}])
+      #   |> do_create
+      # end
 
-      defp to_record(results) when is_list(results), do: results |> Enum.map(&(&1 |> to_record))
-      defp to_record(%{"id" => id, "links" => links, "attributes" => attrs, "type" => type}) do
-        %PcoApi.Record{id: id, links: links, attributes: attrs, type: type}
-      end
+      # defp do_create({:ok, %HTTPoison.Response{status_code: code, body: %{"data" => data}}}) when (code in 200..299) do
+      #   data |> to_record
+      # end
+      # defp do_create({:ok, %HTTPoison.Response{status_code: code, body: body}}) when (code in 200..299), do: body
+      # defp do_create({:ok, %HTTPoison.Response{body: body}}), do: raise "PcoApi ok, but not ok: #{IO.inspect body}"
+      # defp do_create({:error, err}), do: raise "PcoApi error: #{IO.inspect err}"
 
-      def self(%PcoApi.Record{links: %{"self" => self}}), do: get self
-      def self(%PcoApi.Record{id: id}), do: get String.to_integer(id)
+      # def self(%PcoApi.Record{links: %{"self" => self}}), do: get self
+      # def self(%PcoApi.Record{id: id}), do: get String.to_integer(id)
 
-      def new(attrs) when is_list(attrs) do
-        attrs_map = Enum.into(attrs, %{}, fn({k,v}) -> {Atom.to_string(k), v} end)
-        %PcoApi.Record{attributes: attrs_map, type: __MODULE__.type}
-      end
+      # def new(attrs) when is_list(attrs) do
+      #   attrs_map = Enum.into(attrs, %{}, fn({k,v}) -> {Atom.to_string(k), v} end)
+      #   %PcoApi.Record{attributes: attrs_map, type: __MODULE__.type}
+      # end
 
       # HTTPoison.Base API
 
       # if this is a full URL, don't add the endpoint. This allows using direct links.
-      def process_url(url) do
-        configured_endpoint = __MODULE__.api_endpoint
-        endpoint_base = Application.get_env(:pco_api, :endpoint_base)
-        case url |> String.starts_with?(endpoint_base) do
-          true  -> url
-          false -> endpoint_base <> configured_endpoint <> String.replace(url, ~r|^https?://[0-9a-zA-Z:.]+/#{configured_endpoint}|U, "") # enforce the endpoint
-        end
-      end
-      def process_response_body(body), do: body |> Poison.decode!
+      # def process_url(url) do
+      #   configured_endpoint = __MODULE__.api_endpoint
+      #   endpoint_base = Application.get_env(:pco_api, :endpoint_base)
+      #   case url |> String.starts_with?(endpoint_base) do
+      #     true  -> url
+      #     false ->
+      #       url = endpoint_base <> configured_endpoint <> String.replace(url, ~r|^https?://[0-9a-zA-Z:.]+/#{configured_endpoint}|U, "") # enforce the endpoint
+      #       url
+      #   end
+      # end
+      # def process_response_body(body), do: body |> Poison.decode!
     end
   end
 
@@ -79,9 +84,9 @@ defmodule PcoApi.Actions do
     end
   end
 
-  defmacro record_type(type) do
-    quote do
-      def unquote(:type)(), do: unquote(type)
-    end
-  end
+  # defmacro record_type(type) do
+  #   quote do
+  #     def unquote(:type)(), do: unquote(type)
+  #   end
+  # end
 end

--- a/lib/pco_api/actions/create.ex
+++ b/lib/pco_api/actions/create.ex
@@ -1,0 +1,31 @@
+defmodule PcoApi.Actions.Create do
+  defmacro __using__(_opts) do
+    quote do
+      import PcoApi.Actions.Create
+      import PcoApi.Record
+
+      def create(%PcoApi.Record{attributes: _, type: _} = record, url) when is_binary(url) do
+        # TODO: Error handling for when the record isn't created
+        record |> PcoApi.Record.to_json |> create(url)
+      end
+      def create(json, url) when is_binary(json) do
+        url
+        |> post(json, [], hackney: [basic_auth: {PcoApi.key, PcoApi.secret}])
+        |> do_create
+      end
+
+      defp do_create({:ok, %HTTPoison.Response{status_code: code, body: %{"data" => data}}}) when (code in 200..299) do
+        data |> to_record
+      end
+      defp do_create({:ok, %HTTPoison.Response{status_code: code, body: body}}) when (code in 200..299), do: body
+      defp do_create({:ok, %HTTPoison.Response{body: body}}), do: raise "PcoApi ok, but not ok: #{IO.inspect body}"
+      defp do_create({:error, err}), do: raise "PcoApi error: #{IO.inspect err}"
+    end
+  end
+
+  defmacro record_type(type) do
+    quote do
+      def unquote(:type)(), do: unquote(type)
+    end
+  end
+end

--- a/lib/pco_api/actions/create.ex
+++ b/lib/pco_api/actions/create.ex
@@ -4,6 +4,8 @@ defmodule PcoApi.Actions.Create do
       import PcoApi.Actions.Create
       import PcoApi.Record
 
+      def post(url) when is_binary(url), do: create("", url)
+
       def create(%PcoApi.Record{attributes: _, type: _} = record, url) when is_binary(url) do
         # TODO: Error handling for when the record isn't created
         record |> PcoApi.Record.to_json |> create(url)

--- a/lib/pco_api/actions/get.ex
+++ b/lib/pco_api/actions/get.ex
@@ -1,0 +1,27 @@
+defmodule PcoApi.Actions.Get do
+  defmacro __using__(_opts) do
+    quote do
+      import PcoApi.Actions.Get
+      import PcoApi.Record
+
+      def get(url) when is_binary(url), do: get(url, [])
+      # def get(params) when is_list(params), do: get(params, "")
+      def get(params, url) when is_list(params) and is_binary(url), do: get(url, params)
+      def get(url, params) when is_binary(url) do
+        case get(url, [], params: params, hackney: [basic_auth: {PcoApi.key, PcoApi.secret}]) do
+          {:ok, %HTTPoison.Response{status_code: code, body: body}} when (code in 200..299) ->
+            cond do
+              %{"data" => data} = body -> data |> to_record
+              true -> body
+            end
+          {:ok, %HTTPoison.Response{body: body}} ->
+            %{"errors" => [%{"detail" => detail, "title" => title}]} = body
+            raise "Request returned non-200 response. Error: #{title}: #{detail}"
+          {:error, error} ->
+            IO.inspect error
+            raise "PcoApi.People error"
+        end
+      end
+    end
+  end
+end

--- a/lib/pco_api/actions/get.ex
+++ b/lib/pco_api/actions/get.ex
@@ -18,7 +18,6 @@ defmodule PcoApi.Actions.Get do
             %{"errors" => [%{"detail" => detail, "title" => title}]} = body
             raise "Request returned non-200 response. Error: #{title}: #{detail}"
           {:error, error} ->
-            IO.inspect error
             raise "PcoApi.People error"
         end
       end

--- a/lib/pco_api/actions/list.ex
+++ b/lib/pco_api/actions/list.ex
@@ -1,0 +1,10 @@
+defmodule PcoApi.Actions.List do
+  defmacro __using__(_opts) do
+    quote do
+      import PcoApi.Actions.List
+      import PcoApi.Record
+
+      def list, do: list([])
+    end
+  end
+end

--- a/lib/pco_api/actions/new.ex
+++ b/lib/pco_api/actions/new.ex
@@ -1,0 +1,12 @@
+defmodule PcoApi.Actions.New do
+  defmacro __using__(_opts) do
+    quote do
+      import PcoApi.Actions.New
+
+      def new(attrs, type) when is_list(attrs) and is_binary(type) do
+        attrs_map = Enum.into(attrs, %{}, fn({k,v}) -> {Atom.to_string(k), v} end)
+        %PcoApi.Record{attributes: attrs_map, type: type}
+      end
+    end
+  end
+end

--- a/lib/pco_api/actions/self.ex
+++ b/lib/pco_api/actions/self.ex
@@ -1,0 +1,9 @@
+defmodule PcoApi.Actions.Self do
+  defmacro __using__(_opts)do
+    quote do
+      import PcoApi.Actions.Self
+
+      def self(%PcoApi.Record{links: %{"self" => self}}), do: get self
+    end
+  end
+end

--- a/lib/pco_api/client.ex
+++ b/lib/pco_api/client.ex
@@ -21,8 +21,9 @@ defmodule PcoApi.Client do
 
       defp process_url(url) do
         endpoint_base = Application.get_env(:pco_api, :endpoint_base)
-        processed = Regex.replace(~r|^https?://.+/|U, url, "")
-        endpoint_base <> processed
+        processed = Regex.replace(~r|^https?://.+/(people/v2/)?|U, url, "")
+        processed = Regex.replace(~r|people/v2/|, processed, "")
+        endpoint_base <> "people/v2/" <> processed
       end
 
       defp process_response_body(body) do

--- a/lib/pco_api/client.ex
+++ b/lib/pco_api/client.ex
@@ -1,0 +1,33 @@
+defmodule PcoApi.Client do
+  defmacro __using__(_opts) do
+    quote do
+      import PcoApi.Client
+      use HTTPoison.Base
+
+      def request(:get, url, params) do
+        case get(url, [], params: params, hackney: [basic_auth: {PcoApi.key, PcoApi.secret}]) do
+          {:ok, %HTTPoison.Response{status_code: code, body: body}} when (code in 200..299) ->
+            cond do
+              %{"data" => data} = body -> data
+              true -> body
+            end
+          {:ok, %HTTPoison.Response{body: body}} ->
+            %{"errors" => [%{"detail" => detail, "title" => title}]} = body
+            raise "Request returned non-200 response. Error: #{title}: #{detail}"
+          {:error, error} ->
+            raise "PcoApi.People error: #{error}"
+        end
+      end
+
+      defp process_url(url) do
+        endpoint_base = Application.get_env(:pco_api, :endpoint_base)
+        processed = Regex.replace(~r|^https?://.+/|U, url, "")
+        endpoint_base <> processed
+      end
+
+      defp process_response_body(body) do
+        body |> Poison.decode!
+      end
+    end
+  end
+end

--- a/lib/pco_api/people.ex
+++ b/lib/pco_api/people.ex
@@ -3,9 +3,7 @@ defmodule PcoApi.People do
   A set of functions operating on the root path of the People API.
   """
 
-  use PcoApi.Actions
-
-  endpoint "people/v2/"
+  use PcoApi.Actions, only: [:get]
 
   @doc """
   Gets the Person record for the logged in user.

--- a/lib/pco_api/people/address.ex
+++ b/lib/pco_api/people/address.ex
@@ -8,8 +8,8 @@ defmodule PcoApi.People.Address do
   """
 
   use PcoApi.Actions
-  endpoint "people/v2/"
-  record_type "Address"
+  # endpoint "people/v2/"
+  # record_type "Address"
 
   @doc """
   Gets associated Address records from a Person Record from links.

--- a/lib/pco_api/people/address.ex
+++ b/lib/pco_api/people/address.ex
@@ -8,33 +8,31 @@ defmodule PcoApi.People.Address do
   """
 
   use PcoApi.Actions
-  # endpoint "people/v2/"
-  # record_type "Address"
 
   @doc """
-  Gets associated Address records from a Person Record from links.
+  Lists associated Address records from a Person Record from links.
 
   ## Example:
 
-      iex> %PcoApi.Record{type: "Person", links: %{"addresses" => "http://example.com"}} |> PcoApi.People.Address.get
+      iex> %PcoApi.Record{type: "Person", links: %{"addresses" => "http://example.com"}} |> PcoApi.People.Address.list
       %PcoApi.Record{type: "Address", ...}
 
   """
-  def get(%PcoApi.Record{type: "Person", links: %{"addresses" => url}}), do: get url
+  def list(%PcoApi.Record{type: "Person", links: %{"addresses" => url}}), do: get(url)
 
   @doc """
-  Gets associated Address records from a Person Record when no address link is found.
+  Lists associated Address records from a Person Record when no address link is found.
 
   Sometimes a record may not include an address link. This function recreates a URL to
-  get the associated records just based off of the Person id.
+  list the associated records just based off of the Person id.
 
   ## Example:
 
-      iex> %PcoApi.Record{type: "Person", id: 1} |> PcoApi.People.Address.get
+      iex> %PcoApi.Record{type: "Person", id: 1} |> PcoApi.People.Address.list
       %PcoApi.Record{type: "Address", id: 1, ...}
 
   """
-  def get(%PcoApi.Record{type: "Person", id: id}), do: get("people/#{id}/addresses")
+  def list(%PcoApi.Record{type: "Person", id: id}), do: get("people/#{id}/addresses")
 
   @doc """
   Gets a single Address for a Person.
@@ -58,4 +56,6 @@ defmodule PcoApi.People.Address do
   def create(%PcoApi.Record{type: "Person", id: person_id}, %PcoApi.Record{} = record) do
     record |> create("people/#{person_id}/addresses")
   end
+
+  def new(attrs) when is_list(attrs), do: new(attrs, "Address")
 end

--- a/lib/pco_api/people/campus.ex
+++ b/lib/pco_api/people/campus.ex
@@ -8,5 +8,9 @@ defmodule PcoApi.People.Campus do
   """
 
   use PcoApi.Actions
-  endpoint "people/v2/campuses/"
+
+  def list, do: list([])
+  def list(params) when is_list(params), do: get(params, "campuses")
+
+  def get(id) when is_integer(id), do: get("campuses/#{id}")
 end

--- a/lib/pco_api/people/email.ex
+++ b/lib/pco_api/people/email.ex
@@ -1,0 +1,14 @@
+defmodule PcoApi.People.Email do
+  use PcoApi.Actions
+  # use PcoApi.Actions
+  # endpoint "people/v2/"
+  # record_type "Email"
+
+  def get, do: get("people/v2/emails")
+  def get(id) when is_integer(id), do: get("people/v2/emails/#{id}")
+
+  def create(%PcoApi.Record{type: "Person", id: person_id}, %PcoApi.Record{type: "Email"} = record) do
+    record |> create("people/#{person_id}/emails")
+  end
+end
+

--- a/lib/pco_api/people/email.ex
+++ b/lib/pco_api/people/email.ex
@@ -1,14 +1,24 @@
 defmodule PcoApi.People.Email do
   use PcoApi.Actions
-  # use PcoApi.Actions
-  # endpoint "people/v2/"
-  # record_type "Email"
 
-  def get, do: get("people/v2/emails")
-  def get(id) when is_integer(id), do: get("people/v2/emails/#{id}")
+  def list(params) when is_list(params), do: get(params, "emails")
 
-  def create(%PcoApi.Record{type: "Person", id: person_id}, %PcoApi.Record{type: "Email"} = record) do
-    record |> create("people/#{person_id}/emails")
-  end
+  def get(id) when is_integer(id), do: get("emails/#{id}")
+
+  @doc """
+  Creates a new email address for a Person record.
+
+  ## Examples
+
+    iex> email = %PcoApi.Record{type: "Email", attributes: %{"location" => "work", "address" => "geo@pco.bz"}}
+    iex> PcoApi.Record{type: "Person", id: 1} |> PcoApi.People.Email.create(email)
+    %PcoApi.Record{type: "Email"}
+
+  """
+  def create(%PcoApi.Record{attributes: _, type: _} = person, %PcoApi.Record{type: "Email"} = record), do: create(record, "people/#{person.id}/emails")
+
+  def self(%PcoApi.Record{type: "Email", id: id}), do: get("emails/#{id}")
+
+  def new(attrs) when is_list(attrs), do: new(attrs, "Email")
 end
 

--- a/lib/pco_api/people/household.ex
+++ b/lib/pco_api/people/household.ex
@@ -1,3 +1,5 @@
 defmodule PcoApi.People.Household do
   use PcoApi.Actions
+
+  def list(params) when is_list(params), do: get(params, "households")
 end

--- a/lib/pco_api/people/list.ex
+++ b/lib/pco_api/people/list.ex
@@ -1,13 +1,18 @@
 defmodule PcoApi.People.List do
-  use PcoApi.Actions
   import PcoApi.RecordAssociation
-
-  endpoint "people/v2/lists/"
-
   linked_association :created_by
   linked_association :owner
   linked_association :people
   linked_association :rules
   linked_association :shares
   linked_association :updated_by
+
+  use PcoApi.Actions
+
+  def list, do: list([])
+  def list(params) when is_list(params), do: get(params, "lists")
+
+  def get(id) when is_integer(id), do: get("lists/#{id}")
+
+  def run(%PcoApi.Record{type: "List", links: %{"self" => url}}), do: post(url <> "/run")
 end

--- a/lib/pco_api/people/list/rule.ex
+++ b/lib/pco_api/people/list/rule.ex
@@ -8,7 +8,6 @@ defmodule PcoApi.People.List.Rule do
   """
 
   use PcoApi.Actions
-  endpoint "people/v2/"
 
   import PcoApi.RecordAssociation
   linked_association :conditions
@@ -23,7 +22,7 @@ defmodule PcoApi.People.List.Rule do
       %PcoApi.Record{type: "Rule", ...}
 
   """
-  def get(%PcoApi.Record{type: "List", links: %{"rules" => url}}), do: get url
+  def list(%PcoApi.Record{type: "List", links: %{"rules" => url}}), do: get url
 
   @doc """
   Gets associated Rule records from a List Record when no rules link is found.
@@ -37,7 +36,7 @@ defmodule PcoApi.People.List.Rule do
       %PcoApi.Record{type: "Rule", id: 1, ...}
 
   """
-  def get(%PcoApi.Record{type: "List", id: id}), do: get("lists/#{id}/rules")
+  def list(%PcoApi.Record{type: "List", id: id}), do: get("lists/#{id}/rules")
 
   @doc """
   Gets a single Rule for a List.

--- a/lib/pco_api/people/person.ex
+++ b/lib/pco_api/people/person.ex
@@ -1,7 +1,4 @@
 defmodule PcoApi.People.Person do
-  import PcoApi.Record
-  use PcoApi.Actions
-
   import PcoApi.RecordAssociation
   linked_association :addresses
   linked_association :apps
@@ -20,14 +17,16 @@ defmodule PcoApi.People.Person do
   linked_association :school
   linked_association :social_profiles
 
-  def list, do: get("people/v2/people")
-  def list(params) when is_list(params), do: get(params, "people/v2/people")
+  use PcoApi.Actions
 
-  def get(id) when is_integer(id), do: get("people/v2/people/#{id}")
+  def list, do: list([])
+  def list(params) when is_list(params), do: get(params, "people")
 
-  def create(%PcoApi.Record{attributes: _, type: _} = record), do: create(record, "people/v2/people")
+  def get(id) when is_integer(id), do: get("people/#{id}")
 
-  def self(%PcoApi.Record{id: id}), do: get "people/v2/people/#{id}"
+  def create(%PcoApi.Record{attributes: _, type: _} = record), do: create(record, "people")
+
+  def self(%PcoApi.Record{id: id}), do: get "people/#{id}"
 
   def new(attrs) when is_list(attrs), do: new(attrs, "Person")
 end

--- a/lib/pco_api/people/person.ex
+++ b/lib/pco_api/people/person.ex
@@ -1,7 +1,6 @@
 defmodule PcoApi.People.Person do
+  import PcoApi.Record
   use PcoApi.Actions
-  endpoint "people/v2/people/"
-  record_type "Person"
 
   import PcoApi.RecordAssociation
   linked_association :addresses
@@ -20,4 +19,24 @@ defmodule PcoApi.People.Person do
   linked_association :phone_numbers
   linked_association :school
   linked_association :social_profiles
+
+  def get, do: get("people/v2/people")
+  def get(id) when is_integer(id), do: get("people/v2/people/#{id}")
+  def get(params) when is_list(params), do: get(params, "people/v2/people")
+  def get(url), do: get(url, [])
+
+  def get(params, url) when is_list(params) and is_binary(url), do: get(url, params)
+  def get(url, params) when is_binary(url) and is_list(params), do: request(:get, url, params) |> to_record
+
+  #use PcoApi.Actions.Create
+  ##### NEEDED HERE
+  def create(%PcoApi.Record{attributes: _, type: _} = record), do: create(record, "people/v2/people")
+  #####
+  def self(%PcoApi.Record{links: %{"self" => self}}), do: get self
+  def self(%PcoApi.Record{id: id}), do: get "people/v2/people/#{id}"
+
+  def new(attrs) when is_list(attrs) do
+    attrs_map = Enum.into(attrs, %{}, fn({k,v}) -> {Atom.to_string(k), v} end)
+    %PcoApi.Record{attributes: attrs_map, type: "Person"}
+  end
 end

--- a/lib/pco_api/people/person.ex
+++ b/lib/pco_api/people/person.ex
@@ -20,23 +20,14 @@ defmodule PcoApi.People.Person do
   linked_association :school
   linked_association :social_profiles
 
-  def get, do: get("people/v2/people")
+  def list, do: get("people/v2/people")
+  def list(params) when is_list(params), do: get(params, "people/v2/people")
+
   def get(id) when is_integer(id), do: get("people/v2/people/#{id}")
-  def get(params) when is_list(params), do: get(params, "people/v2/people")
-  def get(url), do: get(url, [])
 
-  def get(params, url) when is_list(params) and is_binary(url), do: get(url, params)
-  def get(url, params) when is_binary(url) and is_list(params), do: request(:get, url, params) |> to_record
-
-  #use PcoApi.Actions.Create
-  ##### NEEDED HERE
   def create(%PcoApi.Record{attributes: _, type: _} = record), do: create(record, "people/v2/people")
-  #####
-  def self(%PcoApi.Record{links: %{"self" => self}}), do: get self
+
   def self(%PcoApi.Record{id: id}), do: get "people/v2/people/#{id}"
 
-  def new(attrs) when is_list(attrs) do
-    attrs_map = Enum.into(attrs, %{}, fn({k,v}) -> {Atom.to_string(k), v} end)
-    %PcoApi.Record{attributes: attrs_map, type: "Person"}
-  end
+  def new(attrs) when is_list(attrs), do: new(attrs, "Person")
 end

--- a/lib/pco_api/people/school_option.ex
+++ b/lib/pco_api/people/school_option.ex
@@ -1,7 +1,17 @@
 defmodule PcoApi.People.SchoolOption do
-  use PcoApi.Actions
-  endpoint "people/v2/school_options/"
-
   import PcoApi.RecordAssociation
   linked_association :promotes_to_school
+
+  use PcoApi.Actions
+  # endpoint "people/v2/school_options/"
+  def list, do: list([])
+  def list(params) when is_list(params), do: get(params, "school_options")
+
+  def get(id) when is_integer(id), do: get("school_options/#{id}")
+
+  def self(%PcoApi.Record{id: id}), do: get("school_options/#{id}")
+
+  def create(record = %PcoApi.Record{type: "SchoolOption"}), do: create(record, "school_options")
+
+  def new(attrs) when is_list(attrs), do: new(attrs, "SchoolOption")
 end

--- a/lib/pco_api/people/social_profile.ex
+++ b/lib/pco_api/people/social_profile.ex
@@ -8,7 +8,6 @@ defmodule PcoApi.People.SocialProfile do
   """
 
   use PcoApi.Actions
-  endpoint "people/v2/"
 
   import PcoApi.RecordAssociation
   linked_association :person
@@ -22,7 +21,7 @@ defmodule PcoApi.People.SocialProfile do
       %PcoApi.Record{type: "SocialProfile", ...}
 
   """
-  def get(%PcoApi.Record{type: "Person", links: %{"social_profiles" => url}}), do: get url
+  def list(%PcoApi.Record{type: "Person", links: %{"social_profiles" => url}}), do: get url
 
   @doc """
   Gets associated SocialProfile records from a Person record when no cards link is found.
@@ -36,7 +35,7 @@ defmodule PcoApi.People.SocialProfile do
       %PcoApi.Record{type: "SocialProfile", id: 1, ...}
 
   """
-  def get(%PcoApi.Record{type: "Person", id: id}), do: get("people/#{id}/social_profiles")
+  def list(%PcoApi.Record{type: "Person", id: id}), do: get("people/#{id}/social_profiles")
 
   @doc """
   Gets a single SocialProfile for a Person.
@@ -50,4 +49,10 @@ defmodule PcoApi.People.SocialProfile do
 
   """
   def get(%PcoApi.Record{type: "Person", id: person_id}, id), do: get("people/#{person_id}/social_profiles/#{id}")
+
+  def create(%PcoApi.Record{type: "Person"} = person, %PcoApi.Record{type: "SocialProfile"} = record), do: create(record, "people/#{person.id}/social_profiles")
+
+  def self(%PcoApi.Record{type: "SocialProfile", links: %{"self" => url}}), do: get url
+
+  def new(attrs) when is_list(attrs), do: new(attrs, "SocialProfile")
 end

--- a/lib/pco_api/people/tab.ex
+++ b/lib/pco_api/people/tab.ex
@@ -1,7 +1,17 @@
 defmodule PcoApi.People.Tab do
-  use PcoApi.Actions
-  endpoint "people/v2/tabs/"
-
   import PcoApi.RecordAssociation
   linked_association :field_definitions
+
+  use PcoApi.Actions
+
+  def list, do: list([])
+  def list(params) when is_list(params), do: get(params, "tabs")
+
+  def get(id) when is_integer(id), do: get("tabs/#{id}")
+
+  def self(%PcoApi.Record{id: id}), do: get(String.to_integer(id))
+
+  def new(attrs) when is_list(attrs), do: new(attrs, "Tab")
+
+  def create(%PcoApi.Record{type: "Tab"} = record), do: create(record, "tabs")
 end

--- a/lib/pco_api/people/workflow.ex
+++ b/lib/pco_api/people/workflow.ex
@@ -1,8 +1,13 @@
 defmodule PcoApi.People.Workflow do
-  use PcoApi.Actions
-  endpoint "people/v2/workflows/"
-
   import PcoApi.RecordAssociation
   linked_association :cards
   linked_association :steps
+
+  use PcoApi.Actions
+
+  def list(params) when is_list(params), do: get(params, "workflows")
+
+  def get(id) when is_integer(id), do: get("workflows/#{id}")
+
+  def self(%PcoApi.Record{id: id}), do: get(String.to_integer(id))
 end

--- a/lib/pco_api/people/workflow/card.ex
+++ b/lib/pco_api/people/workflow/card.ex
@@ -7,8 +7,7 @@ defmodule PcoApi.People.Workflow.Card do
   associated WorkflowCards.
   """
 
-  use PcoApi.Actions
-  endpoint "people/v2/"
+  use PcoApi.Actions, only: [:get, :list]
 
   import PcoApi.RecordAssociation
   linked_association :activities
@@ -25,7 +24,7 @@ defmodule PcoApi.People.Workflow.Card do
       %PcoApi.Record{type: "WorkflowCard", ...}
 
   """
-  def get(%PcoApi.Record{type: "Workflow", links: %{"cards" => url}}), do: get url
+  def list(%PcoApi.Record{type: "Workflow", links: %{"cards" => url}}), do: get url
 
   @doc """
   Gets associated WorkflowCard records from a Workflow Record when no cards link is found.
@@ -39,7 +38,7 @@ defmodule PcoApi.People.Workflow.Card do
       %PcoApi.Record{type: "WorkflowCard", id: 1, ...}
 
   """
-  def get(%PcoApi.Record{type: "Workflow", id: id}), do: get("workflows/#{id}/cards")
+  def list(%PcoApi.Record{type: "Workflow", id: id}), do: get("workflows/#{id}/cards")
 
   @doc """
   Gets a single WorkflowCard for a Workflow.

--- a/lib/pco_api/people/workflow/card/activity.ex
+++ b/lib/pco_api/people/workflow/card/activity.ex
@@ -7,19 +7,18 @@ defmodule PcoApi.People.Workflow.Card.Activity do
   associated WorkflowCardActivities.
   """
 
-  use PcoApi.Actions
-  endpoint "people/v2/workflows/"
+  use PcoApi.Actions, only: [:get, :list]
 
   @doc """
   Gets associated WorkflowCard records from a Workflow Record from links.
 
   ## Example:
 
-      iex> %PcoApi.Record{type: "WorkflowCard", links: %{"activities" => "http://example.com"}} |> PcoApi.People.Workflow.Card.Activity.get
+      iex> %PcoApi.Record{type: "WorkflowCard", links: %{"activities" => "http://example.com"}} |> PcoApi.People.Workflow.Card.Activity.list
       %PcoApi.Record{type: "WorkflowCardActivity", ...}
 
   """
-  def get(%PcoApi.Record{type: "WorkflowCard", links: %{"activities" => url}}), do: get url
+  def list(%PcoApi.Record{type: "WorkflowCard", links: %{"activities" => url}}), do: get url
 
   @doc """
   Gets associated WorkflowCardActivities records from a WorkflowCard Record when no activities link is found.
@@ -29,11 +28,11 @@ defmodule PcoApi.People.Workflow.Card.Activity do
 
   ## Example:
 
-      iex> %PcoApi.Record{type: "WorkflowCard", links: %{"self" => "http://example.com"}} |> PcoApi.People.Workflow.Card.Activity.get
+      iex> %PcoApi.Record{type: "WorkflowCard", links: %{"self" => "http://example.com"}} |> PcoApi.People.Workflow.Card.Activity.list
       #%PcoApi.Record{type: "WorkflowCardActivity", ...}
 
   """
-  def get(%PcoApi.Record{type: "WorkflowCard", links: %{"self" => url}}), do: get("#{url}/activities")
+  def list(%PcoApi.Record{type: "WorkflowCard", links: %{"self" => url}}), do: get("#{url}/activities")
 
   @doc """
   Gets a single WorkflowCardActivity for a WorkflowCard.

--- a/lib/pco_api/people/workflow/card/note.ex
+++ b/lib/pco_api/people/workflow/card/note.ex
@@ -8,18 +8,17 @@ defmodule PcoApi.People.Workflow.Card.Note do
   """
 
   use PcoApi.Actions
-  endpoint "people/v2/workflows/"
 
   @doc """
   Gets associated WorkflowCard records from a Workflow Record from links.
 
   ## Example:
 
-      iex> %PcoApi.Record{type: "WorkflowCard", links: %{"notes" => "http://example.com"}} |> PcoApi.People.Workflow.Card.Note.get
+      iex> %PcoApi.Record{type: "WorkflowCard", links: %{"notes" => "http://example.com"}} |> PcoApi.People.Workflow.Card.Note.list
       %PcoApi.Record{type: "WorkflowCardNote", ...}
 
   """
-  def get(%PcoApi.Record{type: "WorkflowCard", links: %{"notes" => url}}), do: get url
+  def list(%PcoApi.Record{type: "WorkflowCard", links: %{"notes" => url}}), do: get url
 
   @doc """
   Gets associated WorkflowCardNotes records from a WorkflowCard Record when no notes link is found.
@@ -29,11 +28,11 @@ defmodule PcoApi.People.Workflow.Card.Note do
 
   ## Example:
 
-      iex> %PcoApi.Record{type: "WorkflowCard", links: %{"self" => "http://example.com"}} |> PcoApi.People.Workflow.Card.Note.get
+      iex> %PcoApi.Record{type: "WorkflowCard", links: %{"self" => "http://example.com"}} |> PcoApi.People.Workflow.Card.Note.list
       #%PcoApi.Record{type: "WorkflowCardNote", ...}
 
   """
-  def get(%PcoApi.Record{type: "WorkflowCard", links: %{"self" => url}}), do: get("#{url}/notes")
+  def list(%PcoApi.Record{type: "WorkflowCard", links: %{"self" => url}}), do: get("#{url}/notes")
 
   @doc """
   Gets a single WorkflowCardNote for a WorkflowCard.
@@ -61,4 +60,8 @@ defmodule PcoApi.People.Workflow.Card.Note do
 
   """
   def get(%PcoApi.Record{type: "WorkflowCard", links: %{"self" => url}}, id), do: get(url <> "/notes/" <> id)
+
+  def new(attrs), do: new(attrs, "WorkflowCardNote")
+
+  def create(%PcoApi.Record{type: "WorkflowCard", links: %{"self" => url}} = card, %PcoApi.Record{type: "WorkflowCardNote"} = record), do: create(record, url <> "/notes")
 end

--- a/lib/pco_api/people/workflow/step.ex
+++ b/lib/pco_api/people/workflow/step.ex
@@ -7,8 +7,7 @@ defmodule PcoApi.People.Workflow.Step do
   associated WorkflowSteps.
   """
 
-  use PcoApi.Actions
-  endpoint "people/v2/"
+  use PcoApi.Actions, only: [:get]
 
   import PcoApi.RecordAssociation
   linked_association :default_assignee

--- a/lib/pco_api/record.ex
+++ b/lib/pco_api/record.ex
@@ -5,4 +5,11 @@ defmodule PcoApi.Record do
     %{"data" => %{"attributes" => attributes, "type" => type}}
     |> Poison.encode!
   end
+
+  def to_record(results) when is_list(results) do
+    results |> Enum.map(&(&1 |> to_record))
+  end
+  def to_record(%{"id" => id, "links" => links, "attributes" => attrs, "type" => type}) do
+    %PcoApi.Record{id: id, links: links, attributes: attrs, type: type}
+  end
 end

--- a/test/pco_api/people/address_test.exs
+++ b/test/pco_api/people/address_test.exs
@@ -9,37 +9,37 @@ defmodule PcoApi.People.AddressTest do
     {:ok, bypass: bypass}
   end
 
-  test ".get requests the v2 endpoint", %{bypass: bypass} do
+  test ".list requests the v2 endpoint", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert conn.request_path |> String.match?(~r|people/v2|)
       assert "GET" == conn.method
       Plug.Conn.resp(conn, 200, Fixture.read("addresses.json"))
     end
-    record_with_link |> Address.get
+    record_with_link |> Address.list
   end
 
-  test ".get gets addresses with an addresses link", %{bypass: bypass} do
+  test ".list lists addresses with an addresses link", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert "/people/v2/people/1/addresses" == conn.request_path
       Plug.Conn.resp(conn, 200, Fixture.read("addresses.json"))
     end
-    record_with_link |> Address.get
+    record_with_link |> Address.list
   end
 
-  test ".get gets addresses without an address link", %{bypass: bypass} do
+  test ".list lists addresses without an address link", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert "/people/v2/people/1/addresses" == conn.request_path
       Plug.Conn.resp(conn, 200, Fixture.read("addresses.json"))
     end
-    record_without_link |> Address.get
+    record_without_link |> Address.list
   end
 
-  test ".get gets addresses by person id", %{bypass: bypass} do
+  test ".list lists addresses by person id", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert "/people/v2/people/1/addresses" == conn.request_path
       Plug.Conn.resp(conn, 200, Fixture.read("addresses.json"))
     end
-    record_without_link |> Address.get
+    record_without_link |> Address.list
   end
 
   test ".get gets addresses by address id", %{bypass: bypass} do

--- a/test/pco_api/people/campus_test.exs
+++ b/test/pco_api/people/campus_test.exs
@@ -9,21 +9,21 @@ defmodule PcoApi.People.CampusTest do
     {:ok, bypass: bypass}
   end
 
-  test ".get requests the v2 endpoint", %{bypass: bypass} do
+  test ".list requests the v2 endpoint", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert conn.request_path |> String.match?(~r|people/v2|)
       assert "GET" == conn.method
       Plug.Conn.resp(conn, 200, Fixture.read("campuses.json"))
     end
-    Campus.get
+    Campus.list
   end
 
-  test ".get gets campuses", %{bypass: bypass} do
+  test ".list gets campuses", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
-      assert "/people/v2/campuses/" == conn.request_path
+      assert "/people/v2/campuses" == conn.request_path
       Plug.Conn.resp(conn, 200, Fixture.read("campuses.json"))
     end
-    campus = Campus.get
+    campus = Campus.list
     assert [%PcoApi.Record{type: "Campus"} | _rest] = campus
   end
 

--- a/test/pco_api/people/email_test.exs
+++ b/test/pco_api/people/email_test.exs
@@ -1,6 +1,5 @@
 defmodule PcoApi.People.EmailTest do
   use ExUnit.Case
-  doctest PcoApi.People.Email
   alias PcoApi.People.Email
   alias TestHelper.Fixture
 
@@ -10,13 +9,22 @@ defmodule PcoApi.People.EmailTest do
     {:ok, bypass: bypass}
   end
 
-  test ".get requests the v2 endpoint", %{bypass: bypass} do
+  test ".list requests the v2 endpoint", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert "/people/v2/emails" == conn.request_path
       assert "GET" == conn.method
       Plug.Conn.resp(conn, 200, Fixture.dummy)
     end
-    Email.get
+    Email.list
+  end
+
+  test ".list lists emails", %{bypass: bypass} do
+    Bypass.expect bypass, fn conn ->
+      assert "/people/v2/emails" == conn.request_path
+      assert "GET" == conn.method
+      Plug.Conn.resp(conn, 200, Fixture.dummy)
+    end
+    Email.list
   end
 
   test ".get(id) requests a specific email", %{bypass: bypass} do
@@ -26,5 +34,14 @@ defmodule PcoApi.People.EmailTest do
       Plug.Conn.resp(conn, 200, Fixture.dummy)
     end
     Email.get(1)
+  end
+
+  test ".create posts to create an email", %{bypass: bypass} do
+    Bypass.expect bypass, fn conn ->
+      assert "/people/v2/people/1/emails" == conn.request_path
+      assert "POST" == conn.method
+      Plug.Conn.resp(conn, 200, Fixture.dummy)
+    end
+    Email.create(%PcoApi.Record{type: "Person", id: 1}, %PcoApi.Record{type: "Email"})
   end
 end

--- a/test/pco_api/people/email_test.exs
+++ b/test/pco_api/people/email_test.exs
@@ -1,0 +1,30 @@
+defmodule PcoApi.People.EmailTest do
+  use ExUnit.Case
+  doctest PcoApi.People.Email
+  alias PcoApi.People.Email
+  alias TestHelper.Fixture
+
+  setup do
+    bypass = Bypass.open
+    Application.put_env(:pco_api, :endpoint_base, "http://localhost:#{bypass.port}/")
+    {:ok, bypass: bypass}
+  end
+
+  test ".get requests the v2 endpoint", %{bypass: bypass} do
+    Bypass.expect bypass, fn conn ->
+      assert "/people/v2/emails" == conn.request_path
+      assert "GET" == conn.method
+      Plug.Conn.resp(conn, 200, Fixture.dummy)
+    end
+    Email.get
+  end
+
+  test ".get(id) requests a specific email", %{bypass: bypass} do
+    Bypass.expect bypass, fn conn ->
+      assert "/people/v2/emails/1" == conn.request_path
+      assert "GET" == conn.method
+      Plug.Conn.resp(conn, 200, Fixture.dummy)
+    end
+    Email.get(1)
+  end
+end

--- a/test/pco_api/people/list/rule_test.exs
+++ b/test/pco_api/people/list/rule_test.exs
@@ -9,29 +9,29 @@ defmodule PcoApi.People.List.RuleTest do
     {:ok, bypass: bypass}
   end
 
-  test ".get requests the v2 endpoint", %{bypass: bypass} do
+  test ".list requests the v2 endpoint", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert conn.request_path |> String.match?(~r|people/v2|)
       assert "GET" == conn.method
       Plug.Conn.resp(conn, 200, Fixture.read("rules.json"))
     end
-    bypass |> record_with_link |> Rule.get
+    bypass |> record_with_link |> Rule.list
   end
 
-  test ".get gets rules with a rules link", %{bypass: bypass} do
+  test ".list gets rules with a rules link", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert "/people/v2/lists/1/rules" == conn.request_path
       Plug.Conn.resp(conn, 200, Fixture.read("rules.json"))
     end
-    bypass |> record_with_link |> Rule.get
+    bypass |> record_with_link |> Rule.list
   end
 
-  test ".get gets rules without a rules link", %{bypass: bypass} do
+  test ".list gets rules without a rules link", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert "/people/v2/lists/1/rules" == conn.request_path
       Plug.Conn.resp(conn, 200, Fixture.read("rules.json"))
     end
-    record_without_link |> Rule.get
+    record_without_link |> Rule.list
   end
 
   test ".get gets rules by rule id", %{bypass: bypass} do

--- a/test/pco_api/people/list_test.exs
+++ b/test/pco_api/people/list_test.exs
@@ -10,20 +10,20 @@ defmodule PcoApi.People.ListTest do
     {:ok, bypass: bypass}
   end
 
-  test ".get requests the v2 endpoint", %{bypass: bypass} do
+  test ".list requests the v2 endpoint", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
-      assert "/people/v2/lists/" == conn.request_path
+      assert "/people/v2/lists" == conn.request_path
       assert "GET" == conn.method
       Plug.Conn.resp(conn, 200, Fixture.read("list.json"))
     end
-    List.get
+    List.list
   end
 
-  test ".get returns a list of Record structs", %{bypass: bypass} do
+  test ".list returns a list of Record structs", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       Plug.Conn.resp(conn, 200, Fixture.read("lists.json"))
     end
-    assert [%PcoApi.Record{} | _rest] = List.get
+    assert [%PcoApi.Record{} | _rest] = List.list
   end
 
   test ".get(id) returns a single record", %{bypass: bypass} do
@@ -83,15 +83,26 @@ defmodule PcoApi.People.ListTest do
     assert %PcoApi.Record{} = bypass |> record_with_links |> List.updated_by
   end
 
+  test ".run POSTs to the list's URL", %{bypass: bypass} do
+    Bypass.expect bypass, fn conn ->
+      assert "/people/v2/lists/1/run" == conn.request_path
+      assert "POST" == conn.method
+      Plug.Conn.resp conn, 200, Fixture.dummy
+    end
+    record_with_links(bypass) |> List.run
+  end
+
   defp record_with_links(bypass) do
     %PcoApi.Record{
+      type: "List",
       links: %{
         "created_by" => "http://localhost:#{bypass.port}/people/v2/people/1",
         "owner" => "http://localhost:#{bypass.port}/people/v2/people/2",
         "people" => "http://locahost:#{bypass.port}/people/v2/lists/1/people",
         "rules" => "http://localhost:#{bypass.port}/people/v2/lists/1/rules",
         "shares" => "http://localhost:#{bypass.port}/people/v2/lists/1/shares",
-        "updated_by" => "http://localhost:#{bypass.port}/people/v2/lists/1/updated_by"
+        "updated_by" => "http://localhost:#{bypass.port}/people/v2/lists/1/updated_by",
+        "self" => "http://localhost:#{bypass.port}/people/v2/lists/1"
       }
     }
   end

--- a/test/pco_api/people/person_test.exs
+++ b/test/pco_api/people/person_test.exs
@@ -10,10 +10,9 @@ defmodule PcoApi.People.PersonTest do
     {:ok, bypass: bypass}
   end
 
-  # .get
   test ".get requests the v2 endpoint", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
-      assert "/people/v2/people/" == conn.request_path
+      assert "/people/v2/people" == conn.request_path
       assert "GET" == conn.method
       Plug.Conn.resp(conn, 200, Fixture.read("me.json"))
     end
@@ -22,6 +21,7 @@ defmodule PcoApi.People.PersonTest do
 
   test ".get returns a list of Record structs", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
+      assert "/people/v2/people" == conn.request_path
       Plug.Conn.resp(conn, 200, Fixture.read("people.json"))
     end
     assert [%PcoApi.Record{} | _rest] = Person.get
@@ -38,23 +38,13 @@ defmodule PcoApi.People.PersonTest do
 
   test ".get queries from a params list", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
-      assert "/people/v2/people/" == conn.request_path
+      assert "/people/v2/people" == conn.request_path
       assert "where%5Blast_name%5D=Lessel&where%5Bfirst_name%5D=Geoffrey" == conn.query_string
       Plug.Conn.resp(conn, 200, Fixture.read("people.json"))
     end
     PcoApi.Query.where(first_name: "Geoffrey")
     |> PcoApi.Query.where(last_name: "Lessel")
     |> Person.get
-  end
-
-  test ".get queries a params list and a specific path", %{bypass: bypass} do
-    Bypass.expect bypass, fn conn ->
-      assert "/people/v2/people/foo" == conn.request_path
-      assert "where%5Blast_name%5D=Lessel" == conn.query_string
-      Plug.Conn.resp(conn, 200, Fixture.read("people.json"))
-    end
-    PcoApi.Query.where(last_name: "Lessel")
-    |> Person.get("foo")
   end
 
   test ".self retrieves the details of a Person when passed a single record", %{bypass: bypass} do
@@ -84,7 +74,7 @@ defmodule PcoApi.People.PersonTest do
 
   test ".create with a record link and no url creates a record", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
-      assert "/people/v2/people/" == conn.request_path
+      assert "/people/v2/people" == conn.request_path
       assert "POST" == conn.method
       Plug.Conn.resp(conn, 200, Fixture.dummy)
     end

--- a/test/pco_api/people/school_option_test.exs
+++ b/test/pco_api/people/school_option_test.exs
@@ -10,20 +10,20 @@ defmodule PcoApi.People.SchoolOptionTest do
     {:ok, bypass: bypass}
   end
 
-  test ".get requests the v2 endpoint", %{bypass: bypass} do
+  test ".list requests the v2 endpoint", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
-      assert "/people/v2/school_options/" == conn.request_path
+      assert "/people/v2/school_options" == conn.request_path
       assert "GET" == conn.method
       Plug.Conn.resp(conn, 200, Fixture.read("school_option.json"))
     end
-    SchoolOption.get
+    SchoolOption.list
   end
 
-  test ".get returns a list of Record structs", %{bypass: bypass} do
+  test ".list returns a list of Record structs", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       Plug.Conn.resp(conn, 200, Fixture.read("school_options.json"))
     end
-    assert [%PcoApi.Record{} | _rest] = SchoolOption.get
+    assert [%PcoApi.Record{} | _rest] = SchoolOption.list
   end
 
   test ".get(id) returns a single record", %{bypass: bypass} do
@@ -35,24 +35,14 @@ defmodule PcoApi.People.SchoolOptionTest do
     assert %PcoApi.Record{id: "1"} = school_option
   end
 
-  test ".get queries from a params list", %{bypass: bypass} do
+  test ".list queries from a params list", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
-      assert "/people/v2/school_options/" == conn.request_path
+      assert "/people/v2/school_options" == conn.request_path
       assert "where%5Bvalue%5D=Carlsbad+Elementary" == conn.query_string
       Plug.Conn.resp(conn, 200, Fixture.read("school_options.json"))
     end
     PcoApi.Query.where(value: "Carlsbad Elementary")
-    |> SchoolOption.get
-  end
-
-  test ".get queries a params list and a specific path", %{bypass: bypass} do
-    Bypass.expect bypass, fn conn ->
-      assert "/people/v2/school_options/foo" == conn.request_path
-      assert "where%5Bvalue%5D=Carlsbad+Elementary" == conn.query_string
-      Plug.Conn.resp(conn, 200, Fixture.read("school_options.json"))
-    end
-    PcoApi.Query.where(value: "Carlsbad Elementary")
-    |> SchoolOption.get("foo")
+    |> SchoolOption.list
   end
 
   test ".self retrieves the details of a Workflow when passed a single record", %{bypass: bypass} do
@@ -80,7 +70,24 @@ defmodule PcoApi.People.SchoolOptionTest do
     assert %PcoApi.Record{type: "SchoolOption"} = record_with_link |> SchoolOption.promotes_to_school
   end
 
-  def record_with_link do
+  test ".create POSTs to the endpoint", %{bypass: bypass} do
+    Bypass.expect bypass, fn conn ->
+      assert "/people/v2/school_options" == conn.request_path
+      assert "POST" == conn.method
+      Plug.Conn.resp(conn, 200, Fixture.dummy)
+    end
+    elementary_school |> SchoolOption.create
+  end
+
+  test ".new returns a List Record" do
+    assert %PcoApi.Record{type: "SchoolOption"} = elementary_school
+  end
+
+  defp elementary_school do
+    SchoolOption.new(school_types: ["elementary"], beginning_grade: "1", ending_grade: "2")
+  end
+
+  defp record_with_link do
     url = "https://api.planningcenteronline.com/people/v2/school_options/2"
     %PcoApi.Record{
       links: %{"promotes_to_school" => url},

--- a/test/pco_api/people/social_profile_test.exs
+++ b/test/pco_api/people/social_profile_test.exs
@@ -9,37 +9,37 @@ defmodule PcoApi.People.SocialProfileTest do
     {:ok, bypass: bypass}
   end
 
-  test ".get requests the v2 endpoint", %{bypass: bypass} do
+  test ".list requests the v2 endpoint", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert conn.request_path |> String.match?(~r|people/v2|)
       assert "GET" == conn.method
       Plug.Conn.resp(conn, 200, Fixture.read("social_profiles.json"))
     end
-    record_with_link |> SocialProfile.get
+    record_with_link |> SocialProfile.list
   end
 
-  test ".get gets social_profiles with an social_profiles link", %{bypass: bypass} do
+  test ".list gets social_profiles with an social_profiles link", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert "/people/v2/people/1/social_profiles" == conn.request_path
       Plug.Conn.resp(conn, 200, Fixture.read("social_profiles.json"))
     end
-    record_with_link |> SocialProfile.get
+    record_with_link |> SocialProfile.list
   end
 
-  test ".get gets social_profiles without an address link", %{bypass: bypass} do
+  test ".list gets social_profiles without an address link", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert "/people/v2/people/1/social_profiles" == conn.request_path
       Plug.Conn.resp(conn, 200, Fixture.read("social_profiles.json"))
     end
-    record_with_link |> SocialProfile.get
+    record_with_link |> SocialProfile.list
   end
 
-  test ".get gets social_profiles by person id", %{bypass: bypass} do
+  test ".list gets social_profiles by person id", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert "/people/v2/people/1/social_profiles" == conn.request_path
       Plug.Conn.resp(conn, 200, Fixture.read("social_profiles.json"))
     end
-    record_with_link |> SocialProfile.get
+    record_with_link |> SocialProfile.list
   end
 
   test ".get(id) gets social_profiles by person id", %{bypass: bypass} do
@@ -58,7 +58,20 @@ defmodule PcoApi.People.SocialProfileTest do
     assert %PcoApi.Record{type: "Person"} = social_profile_record_with_links |> SocialProfile.person
   end
 
-  def social_profile_record_with_links do
+  test ".new returns a SocialProfile Record" do
+    assert %PcoApi.Record{type: "SocialProfile"} = profile
+  end
+
+  test ".create POSTs to a Person's social_profiles URL", %{bypass: bypass} do
+    Bypass.expect bypass, fn conn ->
+      assert "/people/v2/people/1/social_profiles" == conn.request_path
+      assert "POST" == conn.method
+      Plug.Conn.resp(conn, 200, Fixture.dummy)
+    end
+    %PcoApi.Record{type: "Person", id: 1} |> SocialProfile.create(profile)
+  end
+
+  defp social_profile_record_with_links do
     person_url = "https://api.planningcenteronline.com/people/v2/people/1"
     self_url = "https://api.planningcenteronline.com/people/v2/social_profiles/1"
     %PcoApi.Record{
@@ -70,7 +83,7 @@ defmodule PcoApi.People.SocialProfileTest do
     }
   end
 
-  def record_with_link do
+  defp record_with_link do
     url = "https://api.planningcenteronline.com/people/v2/people/1/social_profiles"
     %PcoApi.Record{
       links: %{"social_profiles" => url},
@@ -78,10 +91,14 @@ defmodule PcoApi.People.SocialProfileTest do
     }
   end
 
-  def record_without_link do
+  defp record_without_link do
     %PcoApi.Record{
       id: "1",
       type: "Person"
     }
+  end
+
+  defp profile do
+    SocialProfile.new(site: "facebook", url: "http://example.com", verified: false)
   end
 end

--- a/test/pco_api/people/tab_test.exs
+++ b/test/pco_api/people/tab_test.exs
@@ -10,20 +10,20 @@ defmodule PcoApi.People.TabTest do
     {:ok, bypass: bypass}
   end
 
-  test ".get requests the v2 endpoint", %{bypass: bypass} do
+  test ".list requests the v2 endpoint", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
-      assert "/people/v2/tabs/" == conn.request_path
+      assert "/people/v2/tabs" == conn.request_path
       assert "GET" == conn.method
       Plug.Conn.resp(conn, 200, Fixture.read("tab.json"))
     end
-    Tab.get
+    Tab.list
   end
 
-  test ".get returns a list of Record structs", %{bypass: bypass} do
+  test ".list returns a list of Record structs", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       Plug.Conn.resp(conn, 200, Fixture.read("tabs.json"))
     end
-    assert [%PcoApi.Record{} | _rest] = Tab.get
+    assert [%PcoApi.Record{} | _rest] = Tab.list
   end
 
   test ".get(id) returns a single record", %{bypass: bypass} do
@@ -35,24 +35,14 @@ defmodule PcoApi.People.TabTest do
     assert %PcoApi.Record{id: "1"} = tab
   end
 
-  test ".get queries from a params list", %{bypass: bypass} do
+  test ".list queries from a params list", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
-      assert "/people/v2/tabs/" == conn.request_path
+      assert "/people/v2/tabs" == conn.request_path
       assert "where%5Bname%5D=Employment" == conn.query_string
       Plug.Conn.resp(conn, 200, Fixture.read("tabs.json"))
     end
     PcoApi.Query.where(name: "Employment")
-    |> Tab.get
-  end
-
-  test ".get queries a params list and a specific path", %{bypass: bypass} do
-    Bypass.expect bypass, fn conn ->
-      assert "/people/v2/tabs/foo" == conn.request_path
-      assert "where%5Bname%5D=Employment" == conn.query_string
-      Plug.Conn.resp(conn, 200, Fixture.read("tabs.json"))
-    end
-    PcoApi.Query.where(name: "Employment")
-    |> Tab.get("foo")
+    |> Tab.list
   end
 
   test ".self retrieves the details of a Tab when passed a single record", %{bypass: bypass} do
@@ -80,6 +70,19 @@ defmodule PcoApi.People.TabTest do
     assert [%PcoApi.Record{type: "FieldDefinition"} | _rest] = record_with_link |> Tab.field_definitions
   end
 
+  test ".new returns a Tab Record" do
+    assert %PcoApi.Record{type: "Tab"} = new_tab
+  end
+
+  test ".create POSTs to the tab endpoint", %{bypass: bypass} do
+    Bypass.expect bypass, fn conn ->
+      assert "/people/v2/tabs" == conn.request_path
+      assert "POST" == conn.method
+      Plug.Conn.resp(conn, 200, Fixture.dummy)
+    end
+    new_tab |> Tab.create
+  end
+
   def record_with_link do
     field_definitions_url = "https://api.planningcenteronline.com/people/v2/tabs/1/field_definitions"
     self_url = "https://api.planningcenteronline.com/people/v2/tabs"
@@ -87,5 +90,9 @@ defmodule PcoApi.People.TabTest do
       links: %{"field_definitions" => field_definitions_url, "self" => self_url},
       type: "Tab"
     }
+  end
+
+  def new_tab do
+    Tab.new(name: "My Tab", sequence: 1, slug: "my-tab")
   end
 end

--- a/test/pco_api/people/workflow/card/activity_test.exs
+++ b/test/pco_api/people/workflow/card/activity_test.exs
@@ -9,29 +9,29 @@ defmodule PcoApi.People.Workflow.Card.ActivityTest do
     {:ok, bypass: bypass}
   end
 
-  test ".get requests the v2 endpoint", %{bypass: bypass} do
+  test ".list requests the v2 endpoint", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert conn.request_path |> String.match?(~r|people/v2|)
       assert "GET" == conn.method
       Plug.Conn.resp(conn, 200, Fixture.read("workflow_card_activities.json"))
     end
-    record_with_link |> Activity.get
+    record_with_link |> Activity.list
   end
 
-  test ".get gets activities with an activities link", %{bypass: bypass} do
+  test ".list gets activities with an activities link", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert "/people/v2/workflows/1/cards/1/activities" == conn.request_path
       Plug.Conn.resp(conn, 200, Fixture.read("workflow_card_activities.json"))
     end
-    record_with_link |> Activity.get
+    record_with_link |> Activity.list
   end
 
-  test ".get gets activities with only a self link", %{bypass: bypass} do
+  test ".list gets activities with only a self link", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert "/people/v2/workflows/1/cards/1/activities" == conn.request_path
       Plug.Conn.resp(conn, 200, Fixture.read("workflow_card_activities.json"))
     end
-    record_with_self_link |> Activity.get
+    record_with_self_link |> Activity.list
   end
 
   test ".get gets activity by activities id", %{bypass: bypass} do

--- a/test/pco_api/people/workflow/card/note_test.exs
+++ b/test/pco_api/people/workflow/card/note_test.exs
@@ -9,29 +9,29 @@ defmodule PcoApi.People.Workflow.Card.NoteTest do
     {:ok, bypass: bypass}
   end
 
-  test ".get requests the v2 endpoint", %{bypass: bypass} do
+  test ".list requests the v2 endpoint", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert conn.request_path |> String.match?(~r|people/v2|)
       assert "GET" == conn.method
       Plug.Conn.resp(conn, 200, Fixture.read("workflow_card_notes.json"))
     end
-    record_with_link |> Note.get
+    record_with_link |> Note.list
   end
 
-  test ".get gets notes with a notes link", %{bypass: bypass} do
+  test ".list gets notes with a notes link", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert "/people/v2/workflows/1/cards/1/notes" == conn.request_path
       Plug.Conn.resp(conn, 200, Fixture.read("workflow_card_notes.json"))
     end
-    record_with_link |> Note.get
+    record_with_link |> Note.list
   end
 
-  test ".get gets notes with only a self link", %{bypass: bypass} do
+  test ".list gets notes with only a self link", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert "/people/v2/workflows/1/cards/1/notes" == conn.request_path
       Plug.Conn.resp(conn, 200, Fixture.read("workflow_card_notes.json"))
     end
-    record_with_self_link |> Note.get
+    record_with_self_link |> Note.list
   end
 
   test ".get gets note by notes id", %{bypass: bypass} do
@@ -40,6 +40,23 @@ defmodule PcoApi.People.Workflow.Card.NoteTest do
       Plug.Conn.resp(conn, 200, Fixture.read("workflow_card_note.json"))
     end
     record_with_self_link |> Note.get(1)
+  end
+
+  test ".new returns a WorkflowCardNote Record" do
+    assert %PcoApi.Record{type: "WorkflowCardNote"} = new_note
+  end
+
+  test ".create POSTs to the workflow card endpoint", %{bypass: bypass} do
+    Bypass.expect bypass, fn conn ->
+      assert "/people/v2/workflows/1/cards/1/notes" == conn.request_path
+      assert "POST" == conn.method
+      Plug.Conn.resp(conn, 200, Fixture.dummy)
+    end
+    record_with_self_link |> Note.create(new_note)
+  end
+
+  defp new_note do
+    Note.new(note: "This guy is the best!")
   end
 
   defp record_with_link do

--- a/test/pco_api/people/workflow/card_test.exs
+++ b/test/pco_api/people/workflow/card_test.exs
@@ -9,37 +9,37 @@ defmodule PcoApi.People.Workflow.CardTest do
     {:ok, bypass: bypass}
   end
 
-  test ".get requests the v2 endpoint", %{bypass: bypass} do
+  test ".list requests the v2 endpoint", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert conn.request_path |> String.match?(~r|people/v2|)
       assert "GET" == conn.method
       Plug.Conn.resp(conn, 200, Fixture.read("workflow_cards.json"))
     end
-    record_with_link |> Card.get
+    record_with_link |> Card.list
   end
 
-  test ".get gets cards with a cards link", %{bypass: bypass} do
+  test ".list gets cards with a cards link", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert "/people/v2/workflows/1/cards" == conn.request_path
       Plug.Conn.resp(conn, 200, Fixture.read("workflow_cards.json"))
     end
-    record_with_link |> Card.get
+    record_with_link |> Card.list
   end
 
-  test ".get gets cards without a cards link", %{bypass: bypass} do
+  test ".list gets cards without a cards link", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert "/people/v2/workflows/1/cards" == conn.request_path
       Plug.Conn.resp(conn, 200, Fixture.read("workflow_cards.json"))
     end
-    record_without_link |> Card.get
+    record_without_link |> Card.list
   end
 
-  test ".get gets cards by workflow id", %{bypass: bypass} do
+  test ".list gets cards by workflow id", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       assert "/people/v2/workflows/1/cards" == conn.request_path
       Plug.Conn.resp(conn, 200, Fixture.read("workflow_cards.json"))
     end
-    record_without_link |> Card.get
+    record_without_link |> Card.list
   end
 
   test ".get gets cards by card id", %{bypass: bypass} do

--- a/test/pco_api/people/workflow_test.exs
+++ b/test/pco_api/people/workflow_test.exs
@@ -11,20 +11,20 @@ defmodule PcoApi.People.WorkflowTest do
   end
 
   # .get
-  test ".get requests the v2 endpoint", %{bypass: bypass} do
+  test ".list requests the v2 endpoint", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
-      assert "/people/v2/workflows/" == conn.request_path
+      assert "/people/v2/workflows" == conn.request_path
       assert "GET" == conn.method
       Plug.Conn.resp(conn, 200, Fixture.read("workflow.json"))
     end
-    Workflow.get
+    Workflow.list
   end
 
-  test ".get returns a list of Record structs", %{bypass: bypass} do
+  test ".list returns a list of Record structs", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
       Plug.Conn.resp(conn, 200, Fixture.read("workflows.json"))
     end
-    assert [%PcoApi.Record{} | _rest] = Workflow.get
+    assert [%PcoApi.Record{} | _rest] = Workflow.list
   end
 
   test ".get(id) returns a single record", %{bypass: bypass} do
@@ -36,24 +36,14 @@ defmodule PcoApi.People.WorkflowTest do
     assert %PcoApi.Record{id: "1"} = workflow
   end
 
-  test ".get queries from a params list", %{bypass: bypass} do
+  test ".list queries from a params list", %{bypass: bypass} do
     Bypass.expect bypass, fn conn ->
-      assert "/people/v2/workflows/" == conn.request_path
+      assert "/people/v2/workflows" == conn.request_path
       assert "where%5Bname%5D=Visitors" == conn.query_string
       Plug.Conn.resp(conn, 200, Fixture.read("workflows.json"))
     end
     PcoApi.Query.where(name: "Visitors")
-    |> Workflow.get
-  end
-
-  test ".get queries a params list and a specific path", %{bypass: bypass} do
-    Bypass.expect bypass, fn conn ->
-      assert "/people/v2/workflows/foo" == conn.request_path
-      assert "where%5Bname%5D=Visitors" == conn.query_string
-      Plug.Conn.resp(conn, 200, Fixture.read("workflows.json"))
-    end
-    PcoApi.Query.where(name: "Visitors")
-    |> Workflow.get("foo")
+    |> Workflow.list
   end
 
   test ".self retrieves the details of a Workflow when passed a single record", %{bypass: bypass} do


### PR DESCRIPTION
This completely changes the way the API works so we should really discuss. Here are some of the major points (I may have forgotten some as I started this rewrite a week or so ago):
- Split up `PcoApi.Actions` into submodules of `Get`, `Create`, `Self`, `New` (will also make `Update` when the time comes)
- Less magic in the modules for hitting the endpoints
- Split out a `list` function from `get`. `get` is now only responsible for getting singular records. `list` gets a list of records.
- When you define an endpoint module, you'll need to define just a handful of explicit functions:
  - `list\0` to define the listing URL
  - `list\1` to define the URL to use when passed a `Query`
  - `get\1` to define how to get a single record with an ID
  - `create\1` to define the URL used when creating a record
  - `self\1` to define the URL to use when a record needs to get itself but doesn't have a `self` link
  - `new\1` to define what kind of record this module is (ie `Person`, `Address`, etc)

Ignore all the endpoint modules expect `Person` in this PR if you can. I had to comment stuff out to get it to compile so I could test `Person`. Those tests pass, BTW.

What are your thoughts on this approach?
